### PR TITLE
[1.18.X] [Forge] Only render hud elements for ElemnetType.ALL

### DIFF
--- a/forge/src/main/java/net/combatroll/forge/client/ForgeClientEvents.java
+++ b/forge/src/main/java/net/combatroll/forge/client/ForgeClientEvents.java
@@ -4,6 +4,7 @@ import net.combatroll.CombatRoll;
 import net.combatroll.client.gui.HudRenderHelper;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -11,6 +12,8 @@ import net.minecraftforge.fml.common.Mod;
 public class ForgeClientEvents {
     @SubscribeEvent
     public static void onRenderHud(RenderGameOverlayEvent.Post event) {
-        HudRenderHelper.render(event.getMatrixStack(), event.getPartialTicks());
+    	if(ElementType.ALL == event.getType()) {
+            HudRenderHelper.render(event.getMatrixStack(), event.getPartialTicks());
+    	}
     }
 }


### PR DESCRIPTION
In 1.18.X the hud elements get drawn multiple times. In fact for each element type (see `net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType`). This is unnecessary and also causes visual artifacts if other mods shift the elements on screen because then the hud element get drawn in different positions (see [ShoulderSurfing#91](https://github.com/Exopandora/ShoulderSurfing/issues/91)). This PR fixes that issue by checking for element type 'ALL' which gets called before or after all hud elements are rendered, depending on the event used (pre/post). Due to a rework of the forge api in 1.19 this issue is not present in 1.19 versions of the mod.