### PR TITLE
[1.19.X] Fix gui background not rendering when multi roll is recharging

### DIFF
--- a/common/src/main/java/net/combatroll/client/gui/HudRenderHelper.java
+++ b/common/src/main/java/net/combatroll/client/gui/HudRenderHelper.java
@@ -1,6 +1,7 @@
 package net.combatroll.client.gui;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -83,6 +84,8 @@ public class HudRenderHelper {
 
             drawX += horizontalSpacing;
         }
+
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
     }
 
     private record ViewModel(List<Element> elements) {


### PR DESCRIPTION
This PR fixes the background rendering of guis not working when the multi roll hud element is recharging. This also needs to be fixed for 1.18 versions.