### PR TITLE
Enable/Disable rolling combat roll enchantments

### DIFF
--- a/common/src/main/java/net/combatroll/enchantments/AmplifierEnchantment.java
+++ b/common/src/main/java/net/combatroll/enchantments/AmplifierEnchantment.java
@@ -48,6 +48,16 @@ public class AmplifierEnchantment extends Enchantment implements CustomCondition
         return super.getMinPower(level) + 50;
     }
 
+    @Override
+    public boolean isAvailableForEnchantedBookOffer() {
+        return properties.enabled;
+    }
+
+    @Override
+    public boolean isAvailableForRandomSelection() {
+        return properties.enabled;
+    }
+
     // MARK: CustomConditionalEnchantment
 
     @Override


### PR DESCRIPTION
This PR fixes Combat Roll enchantments being selected/rolled in loot tables, even when the enchantment is disabled.